### PR TITLE
Fix flair display bug

### DIFF
--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -2020,11 +2020,10 @@ public class CommentsListActivity extends ListActivity
     		bodyView.setText(item.getBody());
         
         setCommentIndent(view, item.getIndent(), settings);
-        
-        if (!StringUtils.isEmpty(item.getAuthor_flair_text())) {
-            textFlairView.setText(item.getAuthor_flair_text());
-            textFlairView.setVisibility(View.VISIBLE);
-        }
+
+        boolean hasFlair = !StringUtils.isEmpty(item.getAuthor_flair_text());
+        textFlairView.setVisibility(hasFlair ? View.VISIBLE : View.GONE);
+        textFlairView.setText(item.getAuthor_flair_text());
 
         if (voteUpView != null && voteDownView != null) {
 	        if (item.getLikes() == null || "[deleted]".equals(item.getAuthor())) {


### PR DESCRIPTION
The flair of other commenters would show up when the user didn't have any flair of their own due to view recycling in ListViews.
