### PR TITLE
Copy URL to Clipboard context menu item

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -155,6 +155,7 @@
 	<string name="user_profile">%s\'s profile</string>
 	<string name="view_comments">View comments</string>
 	<string name="view_subreddit">View subreddit</string>
+	<string name="copy_url_to_clipboard">Copy URL to clipboard</string>
 	<string name="close_browser">Close browser</string>
 	
 	

--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -52,6 +52,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.telephony.PhoneNumberUtils;
+import android.text.ClipboardManager;
 import android.text.Html;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -1375,6 +1376,8 @@ public class CommentsListActivity extends ListActivity
     			menu.add(0, Constants.HIDE_CONTEXT_ITEM, Menu.NONE, "Hide");
     		}
     		
+    		menu.add(0, Constants.COPY_URL_TO_CLIPBOARD_CONTEXT_ITEM, Menu.NONE, R.string.copy_url_to_clipboard);
+    		
     		menu.add(0, Constants.DIALOG_VIEW_PROFILE, Menu.NONE,
     				String.format(getResources().getString(R.string.user_profile), item.getAuthor()));
     		
@@ -1417,6 +1420,13 @@ public class CommentsListActivity extends ListActivity
     		
     	case Constants.UNHIDE_CONTEXT_ITEM:
     		new HideTask(false, getOpThingInfo(), mSettings, this).execute();
+    		return true;
+    		
+    	case Constants.COPY_URL_TO_CLIPBOARD_CONTEXT_ITEM:
+    		ClipboardManager clipboard = 
+			      (ClipboardManager) getSystemService(CLIPBOARD_SERVICE); 
+			
+			clipboard.setText(getOpThingInfo().getUrl());
     		return true;
     		
     	case Constants.SHARE_CONTEXT_ITEM:

--- a/src/in/shick/diode/common/Constants.java
+++ b/src/in/shick/diode/common/Constants.java
@@ -131,6 +131,7 @@ public class Constants {
 	public static final int HIDE_CONTEXT_ITEM = 1018;
 	public static final int UNHIDE_CONTEXT_ITEM = 1019;
 	public static final int VIEW_SUBREDDIT_CONTEXT_ITEM = 1020;
+	public static final int COPY_URL_TO_CLIPBOARD_CONTEXT_ITEM = 1021;
 
     
     // Special CSS for webviews to match themes

--- a/src/in/shick/diode/threads/ThreadsListActivity.java
+++ b/src/in/shick/diode/threads/ThreadsListActivity.java
@@ -44,7 +44,7 @@ import in.shick.diode.submit.SubmitLinkActivity;
 import in.shick.diode.things.ThingInfo;
 import in.shick.diode.threads.ShowThumbnailsTask.ThumbnailLoadAction;
 import in.shick.diode.user.ProfileActivity;
-import in.shick.diode.filters.FilterListActivity;
+
 import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +64,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.text.ClipboardManager;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -1009,6 +1010,7 @@ public final class ThreadsListActivity extends ListActivity {
     	menu.add(0, Constants.VIEW_SUBREDDIT_CONTEXT_ITEM, 0, R.string.view_subreddit);
     	menu.add(0, Constants.SHARE_CONTEXT_ITEM, 0, R.string.share);
     	menu.add(0, Constants.OPEN_IN_BROWSER_CONTEXT_ITEM, 0, R.string.open_browser);
+    	menu.add(0, Constants.COPY_URL_TO_CLIPBOARD_CONTEXT_ITEM, 0, R.string.copy_url_to_clipboard);
     	
     	if(mSettings.isLoggedIn()){
     		if(!_item.isSaved()){
@@ -1050,6 +1052,13 @@ public final class ThreadsListActivity extends ListActivity {
 		case Constants.OPEN_IN_BROWSER_CONTEXT_ITEM:
 			setLinkClicked(_item);
 			Common.launchBrowser(this, _item.getUrl(), Util.createThreadUri(_item).toString(), false, true, true, mSettings.isSaveHistory());
+			return true;
+			
+		case Constants.COPY_URL_TO_CLIPBOARD_CONTEXT_ITEM:
+			ClipboardManager clipboard = 
+			      (ClipboardManager) getSystemService(CLIPBOARD_SERVICE); 
+			
+			clipboard.setText(_item.getUrl());
 			return true;
 			
 		case Constants.SAVE_CONTEXT_ITEM:


### PR DESCRIPTION
Added a "Copy URL to clipboard" context menu item to both the thread list and the comment view. It was annoying to have to open a link in the browser to copy the URL to send to a friend, so this makes that a bit easier :)