### PR TITLE
Fix JSON parse on Samsung devices running 4.3.

### DIFF
--- a/src/in/shick/diode/things/ThingInfo.java
+++ b/src/in/shick/diode/things/ThingInfo.java
@@ -31,6 +31,7 @@ import android.text.Html;
 import android.text.SpannableString;
 
 import in.shick.diode.markdown.MarkdownURL;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 /**
  * Class representing a thread posting in reddit API.
@@ -455,7 +456,8 @@ public class ThingInfo implements Serializable, Parcelable {
 		this.thumbnail = thumbnail;
 	}
 
-	public void setThumbnailBitmap(Bitmap thumbnailBitmap) {
+  @JsonIgnore
+  public void setThumbnailBitmap(Bitmap thumbnailBitmap) {
 		this.mThumbnailBitmap = thumbnailBitmap;
 	}
 	


### PR DESCRIPTION
This is a one-liner, but I've walking around with the fix on my Verizon Galaxy S3 running 4.3 for the past couple days.

After digging through some Jackson code, I found out what's happening. It is true that when you mark a field `transient`, it won't get (de)serialized. However, it appears that Jackson conforms to the JavaBean spec in that if there's a public getter or setting, it considers that a bean property. In the case of ThingInfo, Jackson was trying to deserialize `thumbnailBitmap` because of the public setter.

In actuality, it looks like it tries to deserialize other similar fields (`thumbnailResource`), for example, but since those fail, it fails quietly. It only just now occurred to me that it might be because `FAIL_ON_UNKNOWN_PROPERTIES` is set to `false`, but I'm not going to go back and verify that just yet.

Why did this start happening and Samsung devices running newer versions of Android? My best guess is that Samsung created a new version of `android.graphics.Bitmap` that has the bean property `imagePath` on it, and that confuses Jackson. That's my best guess. Samsung has messed up other parts of the API before; `ListView` for example.

Everything here might be total bullshit, but I do know that this patch has allowed me to use Diode.

Finally, I bet you could get a performance bump by adding `@JsonIgnore` to all setter functions backed by transient class members.
