### PR TITLE
Fixed markdown link parsing

### DIFF
--- a/src/in/shick/diode/markdown/Markdown.java
+++ b/src/in/shick/diode/markdown/Markdown.java
@@ -57,14 +57,14 @@ public class Markdown {
     
     static final RunAutomaton inlineLinkAutomaton = new RunAutomaton(new RegExp("(" + // Whole match = $1
             "\\[([^\\]]*)\\]" + // Link text = $2
-            "\\(" +
+            " ?\\(" +
             "([^\\)\\\\]|(\\\\.))+" +  // 3 cases: 1. simple URL. 2. escaped right-paren in URL. 3. escaped anything in URL. 
             "\\)" +
             ")", RegExp.NONE).toAutomaton());
     // Use inlineLinkAutomaton to check for whole match, then use inlineLink to capture groups
     static final Pattern inlineLink = Pattern.compile("(" + // Whole match = $1
             "\\[(.*?)\\]" + // Link text = $2
-            "\\(" +
+            " ?\\(" +
             "[ \\t]*" +
             "<?(.*?)>?" + // href = $3
             "[ \\t]*" +


### PR DESCRIPTION
Reddit allows markdown links to have a space between the [] and () tags. These links are not parsed correctly by Diode. Here is an [example comment](http://www.reddit.com/r/pics/comments/1z5xbz/fishing/cfr7eso) demonstrating this issue. This fix has been tested.
