### PR TITLE
Comment listing remembers context.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -103,7 +103,8 @@
 	<string name="click_to_view_all">Click here to view the rest of the comments.</string>
 	<string name="next_threads">next</string>
 	<string name="previous_threads">prev</string>
-	
+
+	<string name="load_in_progress_toast">Please wait, still loading.</string>
 	<string name="error_voting_toast">Error voting. Please try again.</string>
 	<string name="mail_notification_unscheduled">Reddit mail notification service disabled.</string>
 	<string name="mail_notification_scheduled_5min">Reddit mail set to check every 5 minutes.</string>

--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -2233,7 +2233,7 @@ public class CommentsListActivity extends ListActivity
         textFlairView.setText(item.getAuthor_flair_text());
 
         if (voteUpView != null && voteDownView != null) {
-            if (item.getLikes() == null || "[deleted]".equals(item.getAuthor())) {
+            if (item.getLikes() == null || item.isDeletedUser()) {
                 voteUpView.setVisibility(View.GONE);
                 voteDownView.setVisibility(View.GONE);
             }

--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -214,7 +214,7 @@ public class CommentsListActivity extends ListActivity
         registerForContextMenu(getListView());
 
         if (savedInstanceState != null) {
-            Log.d(TAG, "Loading saved instance state");
+            if (Constants.LOGGING) Log.d(TAG, "Loading saved instance state");
             mReplyTargetName = savedInstanceState.getString(Constants.REPLY_TARGET_NAME_KEY);
             mReportTargetName = savedInstanceState.getString(Constants.REPORT_TARGET_NAME_KEY);
             mEditTargetBody = savedInstanceState.getString(Constants.EDIT_TARGET_BODY_KEY);
@@ -2321,7 +2321,7 @@ public class CommentsListActivity extends ListActivity
 
     @Override
     protected void onSaveInstanceState(Bundle state) {
-        Log.d(TAG, "onSaveInstanceState called");
+        if (Constants.LOGGING) Log.d(TAG, "onSaveInstanceState called");
         state.putString(Constants.REPLY_TARGET_NAME_KEY, mReplyTargetName);
         state.putString(Constants.REPORT_TARGET_NAME_KEY, mReportTargetName);
         state.putString(Constants.EDIT_TARGET_BODY_KEY, mEditTargetBody);

--- a/src/in/shick/diode/comments/DownloadCommentsTask.java
+++ b/src/in/shick/diode/comments/DownloadCommentsTask.java
@@ -303,6 +303,10 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
             if (isInsertingEntireThread()) {
                 parseOP(threadThingListing.getData(), commentListingData.getChildren().length == 0 ? null : commentListingData.getChildren()[0].getData());
                 insertedCommentIndex = 0;  // we just inserted the OP into position 0
+                if (!StringUtils.isEmpty(mJumpToCommentId) && mJumpToCommentContext > 0) {
+                    // If viewing context, then the 'first' item will be the context-viewing warning.
+                    insertedCommentIndex++;
+                }
 
                 // at this point we've started displaying comments, so disable the loading screen
                 disableLoadingScreenKeepProgress();

--- a/src/in/shick/diode/comments/DownloadCommentsTask.java
+++ b/src/in/shick/diode/comments/DownloadCommentsTask.java
@@ -98,6 +98,12 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
     private final LinkedList<ThingInfo> mDeferredReplacementList = new LinkedList<ThingInfo>();
 
     /**
+     * Protected default constructor for subclasses, don't allow it to be called normally.
+     */
+    protected DownloadCommentsTask() {
+        // Do nothing
+    }
+    /**
      * Default constructor to do normal comments page
      */
     public DownloadCommentsTask(
@@ -105,7 +111,9 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
         String subreddit,
         String threadId,
         RedditSettings settings,
-        HttpClient client
+        HttpClient client,
+        String contextOP,
+        int contextAmount
     ) {
         attach(activity);
         this.mSubreddit = subreddit;
@@ -113,6 +121,8 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
         this.mSettings = settings;
         this.mClient = client;
         this.mProcessCommentsTask = new ProcessCommentsTask(mActivity);
+        this.mJumpToCommentId = contextOP;
+        this.mJumpToCommentContext = contextAmount;
     }
 
     /**
@@ -128,12 +138,6 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
         return this;
     }
 
-    public DownloadCommentsTask prepareLoadAndJumpToComment(String commentId, int context) {
-        mJumpToCommentId = commentId;
-        mJumpToCommentContext = context;
-        return this;
-    }
-
     // XXX: maxComments is unused for now
     public Boolean doInBackground(Integer... maxComments) {
         HttpEntity entity = null;
@@ -146,16 +150,14 @@ public class DownloadCommentsTask extends AsyncTask<Integer, Long, Boolean>
                 sb.append("/comments/")
                 .append(mThreadId)
                 .append("/z/").append(mMoreChildrenId).append("/.json?")
-                .append(mSettings.getCommentsSortByUrl()).append("&");
-                if (mJumpToCommentContext != 0) {
-                    sb.append("context=").append(mJumpToCommentContext).append("&");
-                }
+                .append(mSettings.getCommentsSortByUrl());
+                // Loading more with context makes no sense
             } else {
                 sb.append("/comments/")
                 .append(mThreadId)
                 .append("/.json?")
                 .append(mSettings.getCommentsSortByUrl());
-                if (mJumpToCommentId != null && mJumpToCommentId.length() > 0 && mJumpToCommentContext != 0) {
+                if (!StringUtils.isEmpty(mJumpToCommentId) && mJumpToCommentContext > 0) {
                     sb.append("&comment=")
                     .append(mJumpToCommentId)
                     .append("&context=")

--- a/src/in/shick/diode/common/Constants.java
+++ b/src/in/shick/diode/common/Constants.java
@@ -183,6 +183,8 @@ public class Constants {
     public static final String VOTE_TARGET_THING_INFO_KEY = "vote_target_thing_info";
     public static final String WHICH_INBOX_KEY = "which_inbox";
     public static final String QUERY_KEY = "search_query";
+    public static final String CONTEXT_OP_ID_KEY = "context_op";
+    public static final String CONTEXT_COUNT_KEY = "context_count";
 
     public static final String SUBMIT_KIND_LINK = "link";
     public static final String SUBMIT_KIND_SELF = "self";
@@ -268,7 +270,7 @@ public class Constants {
         };
     }
 
-
+    public static final String DELETED_USER = "[deleted]";
     // JSON values
     public static final String JSON_AFTER = "after";
     public static final String JSON_AUTHOR = "author";

--- a/src/in/shick/diode/things/ThingInfo.java
+++ b/src/in/shick/diode/things/ThingInfo.java
@@ -54,7 +54,7 @@ public class ThingInfo implements Serializable, Parcelable {
     private String body_html;				//   c m
     private boolean clicked;				// t
     private String context;					//     m
-    private boolean isContext = false;
+    private boolean misContext = false;
     private double created;					// t c m
     private double created_utc;				// t c m
     private String dest;					//     m
@@ -332,11 +332,15 @@ public class ThingInfo implements Serializable, Parcelable {
     }
 
     public void setIsContext(boolean isContext) {
-        this.isContext = isContext;
+        this.misContext = isContext;
     }
 
     public boolean isContext() {
-        return this.isContext;
+        return this.misContext;
+    }
+
+    public boolean isDeletedUser() {
+        return Constants.DELETED_USER.equalsIgnoreCase(this.author);
     }
 
     public void setCreated(double created) {
@@ -550,7 +554,7 @@ public class ThingInfo implements Serializable, Parcelable {
         out.writeValue(url);
         out.writeValue(likes);
 
-        boolean booleans[] = new boolean[10];
+        boolean booleans[] = new boolean[11];
         booleans[0] = clicked;
         booleans[1] = hidden;
         booleans[2] = is_self;
@@ -561,6 +565,7 @@ public class ThingInfo implements Serializable, Parcelable {
         booleans[7] = mIsLoadMoreCommentsPlaceholder;
         booleans[8] = mIsHiddenCommentHead;
         booleans[9] = mIsHiddenCommentDescendant;
+        booleans[10] = misContext;
         out.writeBooleanArray(booleans);
     }
 
@@ -595,7 +600,7 @@ public class ThingInfo implements Serializable, Parcelable {
         url           = (String) in.readValue(null);
         likes         = (Boolean) in.readValue(null);
 
-        boolean booleans[] = new boolean[10];
+        boolean booleans[] = new boolean[11];
         in.readBooleanArray(booleans);
         clicked                        = booleans[0];
         hidden                         = booleans[1];
@@ -607,6 +612,7 @@ public class ThingInfo implements Serializable, Parcelable {
         mIsLoadMoreCommentsPlaceholder = booleans[7];
         mIsHiddenCommentHead           = booleans[8];
         mIsHiddenCommentDescendant     = booleans[9];
+        misContext                     = booleans[10];
     }
 
     public static final Parcelable.Creator<ThingInfo> CREATOR

--- a/src/in/shick/diode/threads/ThreadsListActivity.java
+++ b/src/in/shick/diode/threads/ThreadsListActivity.java
@@ -1069,8 +1069,11 @@ public final class ThreadsListActivity extends ListActivity {
             menu.add(0, Constants.HIDE_CONTEXT_ITEM, 0, "Hide");
         }
 
-        menu.add(0, Constants.DIALOG_VIEW_PROFILE, Menu.NONE,
-                 String.format(getResources().getString(R.string.user_profile), _item.getAuthor()));
+        // Make sure the user isn't '[deleted]'
+        if (!_item.isDeletedUser()) {
+            menu.add(0, Constants.DIALOG_VIEW_PROFILE, Menu.NONE,
+                    String.format(getResources().getString(R.string.user_profile), _item.getAuthor()));
+        }
     }
 
     @Override
@@ -1119,6 +1122,7 @@ public final class ThreadsListActivity extends ListActivity {
             new MyHideTask(false, _item, mSettings, getApplicationContext()).execute();
 
         case Constants.DIALOG_VIEW_PROFILE:
+            assert(!_item.isDeletedUser());
             Intent i = new Intent(this, ProfileActivity.class);
             i.setData(Util.createProfileUri(_item.getAuthor()));
             startActivity(i);

--- a/src/in/shick/diode/user/ProfileActivity.java
+++ b/src/in/shick/diode/user/ProfileActivity.java
@@ -211,7 +211,7 @@ public final class ProfileActivity extends ListActivity
             } else {
                 // Orientation change. Use prior instance.
                 resetUI(new ThingsListAdapter(this, mThingsList));
-                setTitle(mUsername + "'s profile");
+                setTitle(String.format(getResources().getString(R.string.user_profile), mUsername));
             }
             return;
         }


### PR DESCRIPTION
 If the user chooses to load context for a comment, make sure this information is stored, so that when the comments page is reloaded, it will reload with the proper context, rather than reloading
the whole thread.

Say you reply to a comment when in the context view, the app will now
keep the context view, rather than going back to the full thread.

Also fixed an app crash when the user clicks the 'load more comments'
button quickly. (Click one element more than once, or click two very
quickly)

Also added logic to make it so the app won't attempt to load a [deleted]
user's profile. (The context menu doesn't even show up)

Also fixes an issue with markdown not getting parsed correctly in the context view.