### PR TITLE
Adds support for the 'distinguished' field

### DIFF
--- a/res/layout/threads_list_item.xml
+++ b/res/layout/threads_list_item.xml
@@ -125,19 +125,29 @@
 			    />
 	        </LinearLayout>
 		
-			<!-- A bottommost row used for OP posts in commentslist -->		
-		
-			<TextView android:id="@+id/submissionTime_submitter"
-		        android:layout_width="wrap_content"
-		        android:layout_height="wrap_content"
-			    android:layout_marginRight="4dip"
-			    android:text="very recently"
-		        android:visibility="gone"
-		        
-		        android:singleLine="true"
-		        android:ellipsize="marquee"
-		        android:textAppearance="?android:attr/textAppearanceSmall"
-		    />
+			<!-- A bottommost row used for OP posts in commentslist -->
+
+			<LinearLayout
+					android:orientation="horizontal"
+					android:layout_width="fill_parent"
+					android:layout_height="fill_parent">
+				<TextView android:id="@+id/submissionTime"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                          android:text="@string/just_now"
+                    android:visibility="gone"
+
+                    android:singleLine="false"
+                    android:ellipsize="marquee"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+						  android:layout_marginRight="2dip"/>
+				<TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:id="@+id/submitterName" android:singleLine="false" android:layout_marginRight="4dip"
+                        android:visibility="gone"/>
+			</LinearLayout>
 		</LinearLayout>
 		
 		<LinearLayout android:id="@+id/thumbnail_view"

--- a/res/layout/threads_list_item.xml
+++ b/res/layout/threads_list_item.xml
@@ -125,29 +125,19 @@
 			    />
 	        </LinearLayout>
 		
-			<!-- A bottommost row used for OP posts in commentslist -->
-
-			<LinearLayout
-					android:orientation="horizontal"
-					android:layout_width="fill_parent"
-					android:layout_height="fill_parent">
-				<TextView android:id="@+id/submissionTime"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                          android:text="@string/just_now"
-                    android:visibility="gone"
-
-                    android:singleLine="false"
-                    android:ellipsize="marquee"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-						  android:layout_marginRight="2dip"/>
-				<TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:id="@+id/submitterName" android:singleLine="false" android:layout_marginRight="4dip"
-                        android:visibility="gone"/>
-			</LinearLayout>
+			<!-- A bottommost row used for OP posts in commentslist -->		
+		
+			<TextView android:id="@+id/submissionTime_submitter"
+		        android:layout_width="wrap_content"
+		        android:layout_height="wrap_content"
+			    android:layout_marginRight="4dip"
+			    android:text="very recently"
+		        android:visibility="gone"
+		        
+		        android:singleLine="true"
+		        android:ellipsize="marquee"
+		        android:textAppearance="?android:attr/textAppearanceSmall"
+		    />
 		</LinearLayout>
 		
 		<LinearLayout android:id="@+id/thumbnail_view"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -36,6 +36,7 @@
     
     <color name="pale_blue">#ffcee2ff</color>
     <color name="blue">#ff0000ff</color>
+    <color name="dark_green">#ff00ae00</color>
     <color name="dark_blue">#ff000077</color>
     <color name="purple">#ff551a8b</color>
     <color name="arrow_red">#ffff8a63</color>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -81,7 +81,7 @@
 	
 	<string name="thread_link_button">link</string>
 	<string name="thread_comments_button">comments</string>
-	<string name="thread_time_submitter">%1$s by %2$s</string>
+	<string name="thread_time_submitter">%1$s by</string>
 	
 	<string name="comment_links_button">links</string>
 	<string name="comment_reply_button">reply</string>
@@ -314,5 +314,22 @@
     <string name="pref_title_filter">Edit title filters</string>
     <string name="nsfw">nsfw</string>
     <string name="copy">Copy Url</string>
-    
+
+	<!-- 'When' strings -->
+	<string name="just_now">just now</string>
+	<string name="one_second_ago">1 second ago</string>
+	<string name="n_seconds_ago">%d seconds ago</string>
+	<string name="one_minute_ago">1 minute ago</string>
+	<string name="n_minutes_ago">%d minutes ago</string>
+	<string name="one_hour_ago">1 hour ago</string>
+	<string name="n_hours_ago">%d hours ago</string>
+	<string name="one_day_ago">1 day ago</string>
+	<string name="n_days_ago">%d days ago</string>
+	<string name="one_week_ago">1 week ago</string>
+	<string name="n_weeks_ago">%d weeks ago</string>
+	<string name="one_month_ago">1 month ago</string>
+	<string name="n_months_ago">%d months ago</string>
+	<string name="one_year_ago">1 year ago</string>
+	<string name="n_years_ago">%d years ago</string>
+
 </resources>

--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -21,6 +21,7 @@ package in.shick.diode.comments;
 
 
 import android.content.res.Resources;
+import android.text.SpannableStringBuilder;
 import in.shick.diode.R;
 import in.shick.diode.common.CacheInfo;
 import in.shick.diode.common.Common;
@@ -497,11 +498,9 @@ public class CommentsListActivity extends ListActivity
                     // In addition to stuff from ThreadsListActivity,
                     // we want to show selftext in CommentsListActivity.
 
-                    TextView submissionStuffView = (TextView) view.findViewById(R.id.submissionTime);
-                    TextView submitterView = (TextView) view.findViewById(R.id.submitterName);
+                    TextView submissionStuffView = (TextView) view.findViewById(R.id.submissionTime_submitter);
                     TextView selftextView = (TextView) view.findViewById(R.id.selftext);
 
-                    submitterView.setVisibility(View.VISIBLE);
                     SpannableString distSS = null;
                     if (Constants.DISTINGUISHED_MODERATOR.equalsIgnoreCase(item.getDistinguished())) {
                         distSS = new SpannableString(item.getAuthor() + " [M]");
@@ -509,17 +508,14 @@ public class CommentsListActivity extends ListActivity
                     } else if (Constants.DISTINGUISHED_ADMIN.equalsIgnoreCase(item.getDistinguished())) {
                         distSS = new SpannableString(item.getAuthor() + " [A]");
                         distSS.setSpan(Util.getAdminSpan(getApplicationContext()), 0, distSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-                    }
-                    if (distSS != null) {
-                        submitterView.setText(distSS);
                     } else {
-                        submitterView.setText(item.getAuthor());
+                        distSS = new SpannableString(item.getAuthor());
                     }
-
+                    SpannableStringBuilder ssb = new SpannableStringBuilder(String.format(getResources().getString(R.string.thread_time_submitter),
+                            Util.getTimeAgo(item.getCreated_utc(), getResources())));
+                    ssb.append(" ").append(distSS);
                     submissionStuffView.setVisibility(View.VISIBLE);
-                    submissionStuffView.setText(
-                        String.format(getResources().getString(R.string.thread_time_submitter),
-                                      Util.getTimeAgo(item.getCreated_utc(), getResources())));
+                    submissionStuffView.setText(ssb);
 
                     if (!StringUtils.isEmpty(item.getSpannedSelftext())) {
                         selftextView.setVisibility(View.VISIBLE);

--- a/src/in/shick/diode/comments/CommentsListActivity.java
+++ b/src/in/shick/diode/comments/CommentsListActivity.java
@@ -20,6 +20,7 @@
 package in.shick.diode.comments;
 
 
+import android.content.res.Resources;
 import in.shick.diode.R;
 import in.shick.diode.common.CacheInfo;
 import in.shick.diode.common.Common;
@@ -496,13 +497,29 @@ public class CommentsListActivity extends ListActivity
                     // In addition to stuff from ThreadsListActivity,
                     // we want to show selftext in CommentsListActivity.
 
-                    TextView submissionStuffView = (TextView) view.findViewById(R.id.submissionTime_submitter);
+                    TextView submissionStuffView = (TextView) view.findViewById(R.id.submissionTime);
+                    TextView submitterView = (TextView) view.findViewById(R.id.submitterName);
                     TextView selftextView = (TextView) view.findViewById(R.id.selftext);
+
+                    submitterView.setVisibility(View.VISIBLE);
+                    SpannableString distSS = null;
+                    if (Constants.DISTINGUISHED_MODERATOR.equalsIgnoreCase(item.getDistinguished())) {
+                        distSS = new SpannableString(item.getAuthor() + " [M]");
+                        distSS.setSpan(Util.getModeratorSpan(getApplicationContext()), 0, distSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    } else if (Constants.DISTINGUISHED_ADMIN.equalsIgnoreCase(item.getDistinguished())) {
+                        distSS = new SpannableString(item.getAuthor() + " [A]");
+                        distSS.setSpan(Util.getAdminSpan(getApplicationContext()), 0, distSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    }
+                    if (distSS != null) {
+                        submitterView.setText(distSS);
+                    } else {
+                        submitterView.setText(item.getAuthor());
+                    }
 
                     submissionStuffView.setVisibility(View.VISIBLE);
                     submissionStuffView.setText(
                         String.format(getResources().getString(R.string.thread_time_submitter),
-                                      Util.getTimeAgo(item.getCreated_utc()), item.getAuthor()));
+                                      Util.getTimeAgo(item.getCreated_utc(), getResources())));
 
                     if (!StringUtils.isEmpty(item.getSpannedSelftext())) {
                         selftextView.setVisibility(View.VISIBLE);
@@ -535,7 +552,7 @@ public class CommentsListActivity extends ListActivity
                         submitterView.setText(item.getAuthor() + " [S]");
                     else
                         submitterView.setText(item.getAuthor());
-                    submissionTimeView.setText(Util.getTimeAgo(item.getCreated_utc()));
+                    submissionTimeView.setText(Util.getTimeAgo(item.getCreated_utc(), getResources()));
 
                     setCommentIndent(view, item.getIndent(), mSettings);
 
@@ -695,29 +712,6 @@ public class CommentsListActivity extends ListActivity
         mCommentsAdapter.notifyDataSetChanged();  // Just in case
         getListView().setDivider(null);
         Common.updateListDrawables(this, mSettings.getTheme());
-    }
-
-    /**
-     * Mark the OP submitter comments
-     */
-    void markSubmitterComments() {
-        if (getOpThingInfo() == null || mCommentsAdapter == null)
-            return;
-
-        SpannableString authorSS = new SpannableString(getOpThingInfo().getAuthor() + " [S]");
-        ForegroundColorSpan fcs;
-        if (Util.isLightTheme(mSettings.getTheme()))
-            fcs = new ForegroundColorSpan(getResources().getColor(R.color.blue));
-        else
-            fcs = new ForegroundColorSpan(getResources().getColor(R.color.pale_blue));
-        authorSS.setSpan(fcs, 0, authorSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-
-        for (int i = 0; i < mCommentsAdapter.getCount(); i++) {
-            ThingInfo ci = mCommentsAdapter.getItem(i);
-            // if it's the OP, mark his name
-            if (getOpThingInfo().getAuthor().equalsIgnoreCase(ci.getAuthor()))
-                ci.setSSAuthor(authorSS);
-        }
     }
 
     void enableLoadingScreen() {
@@ -2007,7 +2001,7 @@ public class CommentsListActivity extends ListActivity
                 urlView.setVisibility(View.VISIBLE);
                 urlView.setText(getOpThingInfo().getUrl());
                 submissionStuffView.setVisibility(View.VISIBLE);
-                sb = new StringBuilder(Util.getTimeAgo(getOpThingInfo().getCreated_utc()))
+                sb = new StringBuilder(Util.getTimeAgo(getOpThingInfo().getCreated_utc(), getResources()))
                 .append(" by ").append(getOpThingInfo().getAuthor());
                 submissionStuffView.setText(sb);
                 // For self posts, you're already there!
@@ -2155,7 +2149,7 @@ public class CommentsListActivity extends ListActivity
             submitterView.setText(item.getSSAuthor());
         else
             submitterView.setText(item.getAuthor());
-        submissionTimeView.setText(Util.getTimeAgo(item.getCreated_utc()));
+        submissionTimeView.setText(Util.getTimeAgo(item.getCreated_utc(), view.getContext().getResources()));
 
         if (item.getSpannedBody() != null)
             bodyView.setText(item.getSpannedBody());

--- a/src/in/shick/diode/common/Constants.java
+++ b/src/in/shick/diode/common/Constants.java
@@ -60,6 +60,11 @@ public class Constants {
     public static final String SUBREDDIT_KIND = "t5";
     public static final String MORE_KIND = "more";
 
+    public static final String DISTINGUISHED_MODERATOR = "moderator";
+    public static final String DISTINGUISHED_ADMIN = "admin";
+    // TODO: Not sure exactly how to handle the "special" case.
+    public static final String DISTINGUISHED_SPECIAL = "special";
+
     public static final int DEFAULT_THREAD_DOWNLOAD_LIMIT = 25;
     public static final int DEFAULT_COMMENT_DOWNLOAD_LIMIT = 200;
     public static final long DEFAULT_FRESH_DURATION = 1800000;  // 30 minutes
@@ -353,6 +358,7 @@ public class Constants {
 
     // A short HTML file returned by reddit, so we can get the modhash
     public static final String MODHASH_URL = REDDIT_BASE_URL + "/r";
+    public static final String NSFW_STRING = "nsfw";
 
 
 }

--- a/src/in/shick/diode/common/util/Util.java
+++ b/src/in/shick/diode/common/util/Util.java
@@ -20,14 +20,15 @@
 package in.shick.diode.common.util;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 
+import android.content.Context;
+import android.content.res.Resources;
+import android.text.style.ForegroundColorSpan;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 
 import android.app.Activity;
 import android.net.Uri;
-import android.text.style.URLSpan;
 import android.util.Log;
 
 import in.shick.diode.R;
@@ -39,14 +40,44 @@ public class Util {
 
     private static final String TAG = "Util";
 
-    public static ArrayList<String> extractUris(URLSpan[] spans) {
-        int size = spans.length;
-        ArrayList<String> accumulator = new ArrayList<String>();
+    // Spans for marking an author as the OP (submitter)
+    private static ForegroundColorSpan LIGHT_OP_FGCS = null;
+    private static ForegroundColorSpan DARK_OP_FGCS = null;
 
-        for (int i = 0; i < size; i++) {
-            accumulator.add(spans[i].getURL());
+    // Spans for marking an author as a moderator
+    // Determined that dark_green looks fine in both light and dark themes.
+    private static ForegroundColorSpan MODERATOR_FGCS = null;
+
+    // Spans for marking an author as an admin
+    // Determined that red looks fine in both light and dark themes.
+    private static ForegroundColorSpan ADMIN_FGCS = null;
+
+    public static ForegroundColorSpan getAdminSpan(Context context) {
+        if (ADMIN_FGCS == null) {
+            ADMIN_FGCS = new ForegroundColorSpan(context.getResources().getColor(R.color.red));
         }
-        return accumulator;
+        return ADMIN_FGCS;
+    }
+
+    public static ForegroundColorSpan getModeratorSpan(Context context) {
+        if (MODERATOR_FGCS == null) {
+            MODERATOR_FGCS = new ForegroundColorSpan(context.getResources().getColor(R.color.dark_green));
+        }
+        return MODERATOR_FGCS;
+    }
+
+    public static ForegroundColorSpan getOPSpan(Context context, int theme) {
+        if (Util.isLightTheme(theme)) {
+            if (LIGHT_OP_FGCS == null) {
+                LIGHT_OP_FGCS = new ForegroundColorSpan(context.getResources().getColor(R.color.blue));
+            }
+            return LIGHT_OP_FGCS;
+        } else {
+            if (DARK_OP_FGCS == null) {
+                DARK_OP_FGCS = new ForegroundColorSpan(context.getResources().getColor(R.color.pale_blue));
+            }
+            return DARK_OP_FGCS;
+        }
     }
 
     /**
@@ -92,57 +123,57 @@ public class Util {
      * @param timeSeconds
      * @return
      */
-    public static String getTimeAgo(long utcTimeSeconds) {
+    public static String getTimeAgo(long utcTimeSeconds, Resources resources) {
         long systime = System.currentTimeMillis() / 1000;
         long diff = systime - utcTimeSeconds;
         if (diff <= 0)
-            return "very recently";
+            return resources.getString(R.string.just_now);
         else if (diff < 60) {
             if (diff == 1)
-                return "1 second ago";
+                return resources.getString(R.string.one_second_ago);
             else
-                return diff + " seconds ago";
+                return String.format(resources.getString(R.string.n_seconds_ago), diff);
         }
         else if (diff < 3600) {
             if ((diff / 60) == 1)
-                return "1 minute ago";
+                return resources.getString(R.string.one_minute_ago);
             else
-                return (diff / 60) + " minutes ago";
+                return String.format(resources.getString(R.string.n_minutes_ago), (diff / 60));
         }
         else if (diff < 86400) { // 86400 seconds in a day
             if ((diff / 3600) == 1)
-                return "1 hour ago";
+                return resources.getString(R.string.one_hour_ago);
             else
-                return (diff / 3600) + " hours ago";
+                return String.format(resources.getString(R.string.n_hours_ago), (diff / 3600));
         }
         else if (diff < 604800) { // 86400 * 7
             if ((diff / 86400) == 1)
-                return "1 day ago";
+                return resources.getString(R.string.one_day_ago);
             else
-                return (diff / 86400) + " days ago";
+                return String.format(resources.getString(R.string.n_days_ago), (diff / 86400));
         }
         else if (diff < 2592000) { // 86400 * 30
             if ((diff / 604800) == 1)
-                return "1 week ago";
+                return resources.getString(R.string.one_week_ago);
             else
-                return (diff / 604800) + " weeks ago";
+                return String.format(resources.getString(R.string.n_weeks_ago), (diff / 604800));
         }
         else if (diff < 31536000) { // 86400 * 365
             if ((diff / 2592000) == 1)
-                return "1 month ago";
+                return resources.getString(R.string.one_month_ago);
             else
-                return (diff / 2592000) + " months ago";
+                return String.format(resources.getString(R.string.n_months_ago), (diff / 2592000));
         }
         else {
             if ((diff / 31536000) == 1)
-                return "1 year ago";
+                return resources.getString(R.string.one_year_ago);
             else
-                return (diff / 31536000) + " years ago";
+                return String.format(resources.getString(R.string.n_years_ago), (diff / 31536000));
         }
     }
 
-    public static String getTimeAgo(double utcTimeSeconds) {
-        return getTimeAgo((long)utcTimeSeconds);
+    public static String getTimeAgo(double utcTimeSeconds, Resources resources) {
+        return getTimeAgo((long)utcTimeSeconds, resources);
     }
 
     public static String showNumComments(int comments) {

--- a/src/in/shick/diode/mail/InboxListActivity.java
+++ b/src/in/shick/diode/mail/InboxListActivity.java
@@ -309,7 +309,7 @@ public final class InboxListActivity extends ListActivity
             builder.append(authorSS);
             // When it was sent
             builder.append(" sent ");
-            builder.append(Util.getTimeAgo(item.getCreated_utc()));
+            builder.append(Util.getTimeAgo(item.getCreated_utc(), getResources()));
             fromInfoView.setText(builder);
 
             subjectView.setText(item.getSubject());

--- a/src/in/shick/diode/things/ThingInfo.java
+++ b/src/in/shick/diode/things/ThingInfo.java
@@ -33,6 +33,7 @@ import android.text.SpannableString;
 
 import in.shick.diode.markdown.MarkdownURL;
 import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
  * Class representing a thread posting in reddit API.
@@ -66,6 +67,10 @@ public class ThingInfo implements Serializable, Parcelable {
     private boolean is_self;				// t
     private Boolean likes;					// t c
     private String link_id;					//   c
+    @JsonProperty("link_author")
+    private String link_author = "";        //   c
+    @JsonProperty("distinguished")
+    private String distinguished = "";      // t c m
 //	private MediaInfo media;				// t		// TODO
 //	private MediaEmbedInfo media_embed;		// t		// TODO
     private String name;					// t c m
@@ -109,6 +114,13 @@ public class ThingInfo implements Serializable, Parcelable {
     public String getAuthor() {
         return author;
     }
+
+    /**
+     * On comment Things only.
+     * Returns the link_author, which is only returned for comments outside its thread.
+     * @return the link author.
+     */
+    public final String getLinkAuthor() { return link_author; }
 
     public String getAuthor_flair_text() {
         return author_flair_text;
@@ -165,6 +177,8 @@ public class ThingInfo implements Serializable, Parcelable {
     public Boolean getLikes() {
         return likes;
     }
+
+    public final String getDistinguished() { return distinguished; }
 
     public String getLink_id() {
         return link_id;
@@ -553,6 +567,8 @@ public class ThingInfo implements Serializable, Parcelable {
         out.writeInt(ups);
         out.writeValue(url);
         out.writeValue(likes);
+        out.writeValue(link_author);
+        out.writeValue(distinguished);
 
         boolean booleans[] = new boolean[11];
         booleans[0] = clicked;
@@ -599,6 +615,8 @@ public class ThingInfo implements Serializable, Parcelable {
         ups           = in.readInt();
         url           = (String) in.readValue(null);
         likes         = (Boolean) in.readValue(null);
+        link_author   = (String) in.readValue(null);
+        distinguished = (String) in.readValue(null);
 
         boolean booleans[] = new boolean[11];
         in.readBooleanArray(booleans);

--- a/src/in/shick/diode/threads/ShowThumbnailsTask.java
+++ b/src/in/shick/diode/threads/ShowThumbnailsTask.java
@@ -7,6 +7,7 @@ import java.lang.ref.SoftReference;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 
+import in.shick.diode.common.Constants;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -93,7 +94,7 @@ public class ShowThumbnailsTask extends AsyncTask<ThumbnailLoadAction, Thumbnail
     }
 
     private Bitmap readBitmapFromNetwork( String url ) {
-        if (url == null)
+        if (url == null || Constants.NSFW_STRING.equalsIgnoreCase(url))
             return null;
 
         InputStream is = null;
@@ -110,7 +111,7 @@ public class ShowThumbnailsTask extends AsyncTask<ThumbnailLoadAction, Thumbnail
         } catch (MalformedURLException e) {
             Log.e(TAG, "Bad ad URL", e);
         } catch (IOException e) {
-            Log.e(TAG, "Could not get remote ad image", e);
+            Log.e(TAG, "Could not get remote ad image: " + url, e);
         } finally {
             try {
                 if( is != null )

--- a/src/in/shick/diode/threads/ThreadsListActivity.java
+++ b/src/in/shick/diode/threads/ThreadsListActivity.java
@@ -598,7 +598,7 @@ public final class ThreadsListActivity extends ListActivity {
 
         titleView.setText(thingInfo.getTitle());
         urlView.setText(thingInfo.getUrl());
-        StringBuilder sb = new StringBuilder(Util.getTimeAgo(thingInfo.getCreated_utc()))
+        StringBuilder sb = new StringBuilder(Util.getTimeAgo(thingInfo.getCreated_utc(), dialog.getContext().getResources()))
         .append(" by ").append(thingInfo.getAuthor())
         .append(" to ").append(thingInfo.getSubreddit());
         submissionStuffView.setText(sb);

--- a/src/in/shick/diode/user/ProfileActivity.java
+++ b/src/in/shick/diode/user/ProfileActivity.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import android.text.SpannableString;
 import in.shick.diode.markdown.Markdown;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -743,6 +744,21 @@ public final class ProfileActivity extends ListActivity
                             ti.setSpannedBody(body.subSequence(0, body.length()-2));
                         else
                             ti.setSpannedBody("");
+
+                        // First test for moderator distinguished
+                        if (Constants.DISTINGUISHED_MODERATOR.equalsIgnoreCase(ti.getDistinguished())) {
+                            SpannableString distSS = new SpannableString(ti.getAuthor() + " [M]");
+                            distSS.setSpan(Util.getModeratorSpan(getApplicationContext()), 0, distSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                            ti.setSSAuthor(distSS);
+                        } else if (Constants.DISTINGUISHED_ADMIN.equalsIgnoreCase(ti.getDistinguished())) {
+                            SpannableString distSS = new SpannableString(ti.getAuthor() + " [A]");
+                            distSS.setSpan(Util.getAdminSpan(getApplicationContext()), 0, distSS.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                            ti.setSSAuthor(distSS);
+                        } else if (ti.getLinkAuthor().equalsIgnoreCase(ti.getAuthor())) {
+                            SpannableString opSpan = new SpannableString(ti.getLinkAuthor() + " [S]");
+                            opSpan.setSpan(Util.getOPSpan(getApplicationContext(), mSettings.getTheme()), 0, opSpan.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+                            ti.setSSAuthor(opSpan);
+                        }
                         _mThingInfos.add(ti);
                     } else if (Constants.THREAD_KIND.equals(tiContainer.getKind())) {
                         ThingInfo ti = tiContainer.getData();


### PR DESCRIPTION
Now comments that are 'distinguished' (moderator or admin) take
precedence over the submitter's style. This will now also show in
threads where the submitter has been distinguished. (This required
creating a separate field for the submitter's name.)

Also made it so that OP's comments are marked as the comments are parsed, not as an after-thought. (Should help the app load a little faster.)

This works in the comments view, and user's profile view. The inbox is
designed differently, so it doesn't work there. Maybe in the future?

Also changed the 'when' strings from inline-constants to be localizable
strings.