### PR TITLE
Enable auto linking to subreddits that start with r/

### DIFF
--- a/src/in/shick/diode/common/util/Util.java
+++ b/src/in/shick/diode/common/util/Util.java
@@ -195,6 +195,8 @@ public class Util {
     public static String absolutePathToURL(String path) {
         if (path.startsWith("/"))
             return Constants.REDDIT_BASE_URL + path;
+        else if (path.startsWith("r/"))
+            return Constants.REDDIT_BASE_URL + "/" + path;
         return path;
     }
 

--- a/src/in/shick/diode/markdown/Markdown.java
+++ b/src/in/shick/diode/markdown/Markdown.java
@@ -79,7 +79,7 @@ public class Markdown {
     static final RunAutomaton autoLinkUrlAutomaton = new RunAutomaton(new RegExp("((https?|ftp):([^'\"> \t\r\n])+)", RegExp.NONE).toAutomaton());
 //    static final Pattern autoLinkEmail = Pattern.compile("<([-.\\w]+\\@[-a-z0-9]+(\\.[-a-z0-9]+)*\\.[a-z]+)>");
 
-    static final RunAutomaton subredditAutomaton = new RunAutomaton(new RegExp("/[rR]/[a-zA-Z0-9]+/?", RegExp.NONE).toAutomaton());
+    static final RunAutomaton subredditAutomaton = new RunAutomaton(new RegExp("[rR]/[a-zA-Z0-9]+/?", RegExp.NONE).toAutomaton());
 
     /**
      * @param txt input
@@ -278,7 +278,7 @@ public class Markdown {
             if (Constants.LOGGING) Log.d(TAG, "pos="+am.start() + " subreddit="+subreddit);
             if (!isOverlapping(am.start(), am.start() + subreddit.length(), startToEndOffsetMap)) {
                 saveStartAndEnd(am.start(), am.start() + subreddit.length(), startToEndOffsetMap);
-                urls.add(new MarkdownURL(am.start(), Util.absolutePathToURL(subreddit), subreddit));
+                urls.add(new MarkdownURL(am.start(), Util.absolutePathToURL(subreddit), "/" + subreddit));
             }
         }
         return txt;


### PR DESCRIPTION
Subreddits that start with /r/ are already auto-linked to. When the subreddit starts with r/ instead of /r/, it turns blue but does not show up as a link when the links dialog pops up. This fixes that.