### PR TITLE
Add a setting to load v.redd.it links directly

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -201,6 +201,9 @@
     <string name="pref_load_javascript">Load Javascript</string>
     <string name="pref_load_plugins">Load Plugins</string>
     <string name="pref_imgur_direct">Open Imgur Images Directly</string>
+    
+    <string name="pref_vreddit_direct">Load v.redd.it links directly</string>
+    <string name="pref_vreddit_direct_hint">Audio will not work</string>
 
 	<string name="pref_homepage">Default starting reddit</string>
 

--- a/res/xml/reddit_preferences.xml
+++ b/res/xml/reddit_preferences.xml
@@ -149,5 +149,11 @@
         android:key="imgur_direct"
         android:defaultValue="true"
         android:title="@string/pref_imgur_direct" />
+    
+    <CheckBoxPreference 
+        android:key="vreddit_direct"
+        android:defaultValue="false"
+        android:title="@string/pref_vreddit_direct" 
+        android:summary="@string/pref_vreddit_direct_hint"/>
 
 </PreferenceScreen>

--- a/src/in/shick/diode/common/Common.java
+++ b/src/in/shick/diode/common/Common.java
@@ -543,10 +543,13 @@ public class Common {
                 }
                 forceDesktopUserAgent = true;
             }
-        }        
-        if(url.contains("v.redd.it")) {
-        	url += "/DASH_600_K";
         }
+        if(settings != null && settings.isLoadVredditLinksDirectly()) {
+        	if(url.contains("v.redd.it")) {
+        		url += "/DASH_600_K";
+        	}
+        }
+
 
         Uri uri = Uri.parse(url);
 

--- a/src/in/shick/diode/common/Common.java
+++ b/src/in/shick/diode/common/Common.java
@@ -543,6 +543,9 @@ public class Common {
                 }
                 forceDesktopUserAgent = true;
             }
+        }        
+        if(url.contains("v.redd.it")) {
+        	url += "/DASH_600_K";
         }
 
         Uri uri = Uri.parse(url);

--- a/src/in/shick/diode/common/Constants.java
+++ b/src/in/shick/diode/common/Constants.java
@@ -325,6 +325,7 @@ public class Constants {
     public static final String PREF_LOAD_JS = "load_javascript";
     public static final String PREF_LOAD_PLUGINS = "load_plugins";
     public static final String PREF_IMGUR_DIRECT = "imgur_direct";
+    public static final String PREF_VREDDIT_DIRECT = "vreddit_direct";
 
     public static final String PREF_SAVE_HISTORY = "save_history";
     public static final String PREF_ALWAYS_SHOW_NEXT_PREVIOUS = "always_show_next_previous";

--- a/src/in/shick/diode/settings/RedditSettings.java
+++ b/src/in/shick/diode/settings/RedditSettings.java
@@ -68,6 +68,8 @@ public class RedditSettings {
      * Should the browser attempt to load imgur images directly?
      */
     private boolean loadImgurImagesDirectly = true;
+    
+    private boolean loadVredditLinksDirectly = false;
 
     private int threadDownloadLimit = Constants.DEFAULT_THREAD_DOWNLOAD_LIMIT;
     private String commentsSortByUrl = Constants.CommentsSort.SORT_BY_BEST_URL;
@@ -152,6 +154,7 @@ public class RedditSettings {
         editor.putBoolean(Constants.PREF_LOAD_JS, this.loadJavascript);
         editor.putBoolean(Constants.PREF_LOAD_PLUGINS, this.loadPlugins);
         editor.putBoolean(Constants.PREF_IMGUR_DIRECT, this.loadImgurImagesDirectly);
+        editor.putBoolean(Constants.PREF_VREDDIT_DIRECT, this.loadVredditLinksDirectly);
 
         // Use external browser instead of BrowserActivity
         editor.putBoolean(Constants.PREF_USE_EXTERNAL_BROWSER, this.useExternalBrowser);
@@ -236,6 +239,7 @@ public class RedditSettings {
         this.setLoadJS(sessionPrefs.getBoolean(Constants.PREF_LOAD_JS, true));
         this.setLoadPlugins(sessionPrefs.getBoolean(Constants.PREF_LOAD_PLUGINS, true));
         this.setLoadImgurImagesDirectly(sessionPrefs.getBoolean(Constants.PREF_IMGUR_DIRECT, true));
+        this.setLoadVredditLinksDirectly(sessionPrefs.getBoolean(Constants.PREF_VREDDIT_DIRECT, false));
 
         // Use external browser instead of BrowserActivity
         this.setUseExternalBrowser(sessionPrefs.getBoolean(Constants.PREF_USE_EXTERNAL_BROWSER, false));
@@ -420,6 +424,10 @@ public class RedditSettings {
     public void setLoadImgurImagesDirectly(boolean newLoadImgurImagesDirectly) {
         this.loadImgurImagesDirectly = newLoadImgurImagesDirectly;
     }
+    
+    public void setLoadVredditLinksDirectly(boolean loadVredditLinksDirectly) {
+    	this.loadVredditLinksDirectly = loadVredditLinksDirectly;
+    }
 
     public boolean isOverwriteUA() {
         return overWriteUA;
@@ -435,6 +443,10 @@ public class RedditSettings {
 
     public boolean isLoadImgurImagesDirectly() {
         return this.loadImgurImagesDirectly;
+    }
+    
+    public boolean isLoadVredditLinksDirectly() {
+    	return this.loadVredditLinksDirectly;
     }
 
 


### PR DESCRIPTION
Loading v.redd.it links currently takes you to the reddit mobile site, which is very slow and unsightly. This allows loading the videos directly. Audio doesn't work though, so it's defaulted to off with a message saying that audio will not work.