### PR TITLE
Target Android Q and fix notifications.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     compile files('libs/jackson-core-asl-1.8.5.jar')
     compile files('libs/jackson-mapper-asl-1.8.5.jar')
 
-    implementation 'org.apache.httpcomponents:httpclient:4.5.6'
+    implementation 'org.apache.httpcomponents:httpclient:4.1.2'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 15
+    compileSdkVersion 29
     buildToolsVersion "27.0.3"
 
     defaultConfig {
@@ -9,7 +9,7 @@ android {
         versionCode 26
         versionName "1.3.2.2"
         minSdkVersion 4
-        targetSdkVersion 26
+        targetSdkVersion 29
     }
 
     buildTypes {
@@ -32,4 +32,6 @@ dependencies {
     compile files('libs/automaton.jar')
     compile files('libs/jackson-core-asl-1.8.5.jar')
     compile files('libs/jackson-mapper-asl-1.8.5.jar')
+
+    implementation 'org.apache.httpcomponents:httpclient:4.5.6'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
     }
     packagingOptions{
         exclude 'META-INF/ASL2.0'
+        exclude 'META-INF/DEPENDENCIES'
     }
 
     lintOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,10 +31,11 @@
 
     <supports-screens />
 
-	<uses-sdk tools:overrideLibrary="androidx.legacy, androidx.legacy.coreui, androidx.legacy.coreutils, androidx.viewpager"/>
-
     <application android:icon="@drawable/icon" android:label="@string/app_name" android:name=".RedditIsFunApplication" android:hardwareAccelerated="true">
-        <activity android:name=".threads.ThreadsListActivity"
+
+		<uses-library android:name ="org.apache.http.legacy" android:required ="false"/>
+
+		<activity android:name=".threads.ThreadsListActivity"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,10 @@
  * along with "diode".  If not, see <http://www.gnu.org/licenses/>.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="in.shick.diode"
-      
-      android:installLocation="auto"
-      >
+	xmlns:tools="http://schemas.android.com/tools"
+	package="in.shick.diode"
+
+	android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -30,7 +30,9 @@
     <uses-permission android:name="com.android.browser.permission.WRITE_HISTORY_BOOKMARKS" />
 
     <supports-screens />
-    
+
+	<uses-sdk tools:overrideLibrary="androidx.legacy, androidx.legacy.coreui, androidx.legacy.coreutils, androidx.viewpager"/>
+
     <application android:icon="@drawable/icon" android:label="@string/app_name" android:name=".RedditIsFunApplication" android:hardwareAccelerated="true">
         <activity android:name=".threads.ThreadsListActivity"
                   android:label="@string/app_name">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
 
     <supports-screens />
 
-    <application android:icon="@drawable/icon" android:label="@string/app_name" android:name=".RedditIsFunApplication" android:hardwareAccelerated="true">
+    <application android:icon="@drawable/icon" android:label="@string/app_name" android:name=".RedditIsFunApplication" android:hardwareAccelerated="true"
+		android:usesCleartextTraffic="true">
 
 		<uses-library android:name ="org.apache.http.legacy" android:required ="false"/>
 

--- a/app/src/main/java/in/shick/diode/common/Common.java
+++ b/app/src/main/java/in/shick/diode/common/Common.java
@@ -558,13 +558,16 @@ public class Common {
                                      boolean requireNewTask, boolean bypassParser, boolean useExternalBrowser,
                                      boolean saveHistory) {
 
-        try {
+
+        //https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-bookmark-browser
+        //No more global history
+/*        try {
             if (saveHistory) {
                 Browser.updateVisitedHistory(context.getContentResolver(), url, true);
             }
         } catch (Exception ex) {
             if (Constants.LOGGING) Log.i(TAG, "Browser.updateVisitedHistory error", ex);
-        }
+        }*/
         boolean forceDesktopUserAgent = false;
         if (!bypassParser && settings != null && settings.isLoadImgurImagesDirectly()) {
             Matcher m = m_imgurRegex.matcher(url);
@@ -682,8 +685,11 @@ public class Common {
     }
 
     public static boolean isClicked(Context context, String url) {
-        Cursor cursor;
-        try {
+        Cursor cursor = null;
+
+        //https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-bookmark-browser
+        //No more global history
+        /*        try {
             cursor = context.getContentResolver().query(
                          Browser.BOOKMARKS_URI,
                          Browser.HISTORY_PROJECTION,
@@ -694,7 +700,7 @@ public class Common {
         } catch (Exception ex) {
             if (Constants.LOGGING) Log.w(TAG, "Error querying Android Browser for history; manually revoked permission?", ex);
             return false;
-        }
+        }*/
 
         if (cursor != null) {
             boolean isClicked = cursor.moveToFirst();  // returns true if cursor is not empty

--- a/app/src/main/java/in/shick/diode/search/RedditSearchActivity.java
+++ b/app/src/main/java/in/shick/diode/search/RedditSearchActivity.java
@@ -22,6 +22,7 @@ public class RedditSearchActivity extends Activity implements OnClickListener, O
 
     private Button btn;
     private EditText searchText;
+    private EditText searchSubreddit;
     private Spinner sortBy;
     private String mSort = Constants.DEFAULT_SEARCH_SORT; //default to show most relevant results first
 
@@ -44,12 +45,28 @@ public class RedditSearchActivity extends Activity implements OnClickListener, O
 
         searchText = (EditText) findViewById(R.id.searchText);
         searchText.setOnKeyListener(this);
+
+        searchSubreddit = (EditText) findViewById(R.id.searchSubreddit);
+        String subreddit = getIntent().getStringExtra("subreddit");
+        if (subreddit != null && !subreddit.trim().equals("")) {
+            searchSubreddit.setText(subreddit);
+        }
     }
 
     private void activityDone()
     {
         Intent intent = new Intent();
-        intent.putExtra("searchurl", "search");
+
+        String subreddit = searchSubreddit.getText().toString();
+        if (subreddit.equals("")) {
+            intent.putExtra("searchurl", "search");
+        } else {
+            intent.putExtra("searchurl", subreddit);
+        }
+
+//        intent.putExtra("searchurl", "search");
+
+
         String query = searchText.getText().toString();
         if(query == null) {
             query = Constants.DEFAULT_REDDIT_SEARCH;

--- a/app/src/main/java/in/shick/diode/threads/DownloadThreadsTask.java
+++ b/app/src/main/java/in/shick/diode/threads/DownloadThreadsTask.java
@@ -57,6 +57,7 @@ public abstract class DownloadThreadsTask extends AsyncTask<Void, Long, Boolean>
     protected String mLastAfter = null;
     protected String mLastBefore = null;
     protected int mLastCount = 0;
+    protected boolean mIsSearch = false;
     protected RedditSettings mSettings = new RedditSettings();
 
     //the GET parameters to be passed when performing a search
@@ -82,6 +83,15 @@ public abstract class DownloadThreadsTask extends AsyncTask<Void, Long, Boolean>
         this(context, client, om, sortByUrl, sortByUrlExtra, subreddit, null, null, Constants.DEFAULT_THREAD_DOWNLOAD_LIMIT);
         mSearchQuery = query;
         mSortSearch = sort;
+    }
+
+    public DownloadThreadsTask(Context context, HttpClient client, ObjectMapper om,
+                               String sortByUrl, String sortByUrlExtra,
+                               String subreddit, String query, String sort, boolean isSearch) {
+        this(context, client, om, sortByUrl, sortByUrlExtra, subreddit, null, null, Constants.DEFAULT_THREAD_DOWNLOAD_LIMIT);
+        mSearchQuery = query;
+        mSortSearch = sort;
+        mIsSearch = isSearch;
     }
 
     public DownloadThreadsTask(Context context, HttpClient client, ObjectMapper om,
@@ -136,23 +146,42 @@ public abstract class DownloadThreadsTask extends AsyncTask<Void, Long, Boolean>
             // If refreshing or something, use the previously used URL to get the threads.
             // Picking a new subreddit will erase the saved URL, getting rid of after= and before=.
             // subreddit.length != 0 means you are going Next or Prev, which creates new URL.
+
+            //Load front page task
             if (Constants.FRONTPAGE_STRING.equals(mSubreddit)) {
                 sb = new StringBuilder(Constants.REDDIT_BASE_URL + "/").append(mSortByUrl)
                 .append(".json?").append(mSortByUrlExtra).append("&");
             }
-            //prepare a search query
-            else if(Constants.REDDIT_SEARCH_STRING.equals(mSubreddit)) {
-                sb = new StringBuilder(Constants.REDDIT_BASE_URL + "/search/").append(".json?q=")
-                .append(URLEncoder.encode(mSearchQuery, "utf8")).append("&sort=" + mSortSearch);
-            } else if(Constants.REDDIT_SAVED_STRING.equals(mSubreddit)) {
+
+            else if (mIsSearch) { //Search task
+                //No subreddit specified, search all of reddit
+                if (Constants.REDDIT_SEARCH_STRING.equals(mSubreddit) || mSubreddit == null) {
+                    sb = new StringBuilder(Constants.REDDIT_BASE_URL + "/search/").append(".json?q=")
+                            .append(URLEncoder.encode(mSearchQuery, "utf8"))
+                            .append("&sort=" + mSortSearch);
+                } else {
+                    //Only search within specified subreddit
+                    sb = new StringBuilder(Constants.REDDIT_BASE_URL + "/r/" + mSubreddit.trim() + "/search").append(".json?q=")
+                            .append(URLEncoder.encode(mSearchQuery, "utf8"))
+                            .append("&sort=" + mSortSearch)
+                            .append("&restrict_sr=on");
+                }
+            }
+
+            //Saved posts task
+            else if(Constants.REDDIT_SAVED_STRING.equals(mSubreddit)) {
                 // Appending the ? without query params is still valid.
                 sb = new StringBuilder(mDTTSavedURI.toString()).append('?');
-            } else {
+            }
+
+            //Load specified subreddit task
+            else {
                 sb = new StringBuilder(Constants.REDDIT_BASE_URL + "/r/")
                 .append(mSubreddit.trim())
                 .append("/").append(mSortByUrl).append(".json?")
                 .append(mSortByUrlExtra).append("&");
             }
+
             // "before" always comes back null unless you provide correct "count"
             if (mAfter != null) {
                 // count: 25, 50, ...

--- a/app/src/main/java/in/shick/diode/threads/ThreadsListActivity.java
+++ b/app/src/main/java/in/shick/diode/threads/ThreadsListActivity.java
@@ -337,7 +337,7 @@ public final class ThreadsListActivity extends ListActivity {
                 //rather than having to use regex to split apart a string
                 //could probably do away with the "subreddit" field since we're
                 //using a modified constructor anyways
-                mObjectStates.mCurrentDownloadThreadsTask = new MyDownloadThreadsTask(intent.getExtras().getString("searchurl"), intent.getExtras().getString("query"),intent.getExtras().getString("sort"));
+                mObjectStates.mCurrentDownloadThreadsTask = new MyDownloadThreadsTask(intent.getExtras().getString("searchurl"), intent.getExtras().getString("query"),intent.getExtras().getString("sort"), true);
                 mObjectStates.mCurrentDownloadThreadsTask.execute();
             }
             break;
@@ -766,13 +766,13 @@ public final class ThreadsListActivity extends ListActivity {
             attach(ThreadsListActivity.this);
         }
 
-        public MyDownloadThreadsTask(String subreddit, String query, String sort) {
+        public MyDownloadThreadsTask(String subreddit, String query, String sort, boolean isSearch) {
             super(getApplicationContext(),
-                  ThreadsListActivity.this.mClient,
-                  ThreadsListActivity.this.mObjectMapper,
-                  ThreadsListActivity.this.mSortByUrl,
-                  ThreadsListActivity.this.mSortByUrlExtra,
-                  subreddit, query, sort);
+                    ThreadsListActivity.this.mClient,
+                    ThreadsListActivity.this.mObjectMapper,
+                    ThreadsListActivity.this.mSortByUrl,
+                    ThreadsListActivity.this.mSortByUrlExtra,
+                    subreddit, query, sort, isSearch);
             attach(ThreadsListActivity.this);
         }
 
@@ -1296,7 +1296,9 @@ public final class ThreadsListActivity extends ListActivity {
             Common.goHome(this);
             break;
         case R.id.search:
-            startActivityForResult(new Intent(this, RedditSearchActivity.class), Constants.ACTIVITY_SEARCH_REDDIT);
+            Intent intent = new Intent(this, RedditSearchActivity.class);
+            if (!mSubreddit.equals(Constants.FRONTPAGE_STRING)) intent.putExtra("subreddit", mSubreddit);
+            startActivityForResult(intent, Constants.ACTIVITY_SEARCH_REDDIT);
             break;
         case R.id.saved_comments_menu_id:
             Intent toSC = new Intent(getApplicationContext(), SavedCommentsActivity.class);

--- a/app/src/main/java/in/shick/diode/threads/ThreadsListActivity.java
+++ b/app/src/main/java/in/shick/diode/threads/ThreadsListActivity.java
@@ -1297,7 +1297,7 @@ public final class ThreadsListActivity extends ListActivity {
             break;
         case R.id.search:
             Intent intent = new Intent(this, RedditSearchActivity.class);
-            if (!mSubreddit.equals(Constants.FRONTPAGE_STRING)) intent.putExtra("subreddit", mSubreddit);
+            if (!mSubreddit.equals(Constants.FRONTPAGE_STRING) && !mSubreddit.equals(Constants.REDDIT_SEARCH_STRING)) intent.putExtra("subreddit", mSubreddit);
             startActivityForResult(intent, Constants.ACTIVITY_SEARCH_REDDIT);
             break;
         case R.id.saved_comments_menu_id:

--- a/app/src/main/res/layout/search_view.xml
+++ b/app/src/main/res/layout/search_view.xml
@@ -10,6 +10,19 @@
         </EditText>
         <Button android:layout_height="wrap_content" android:layout_width="wrap_content" android:id="@+id/searchButton" android:text="@string/search_button"></Button>
     </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/searchSubreddit"
+            android:layout_weight="1"
+            android:layout_width="0dip"
+            android:layout_height="wrap_content"
+            android:hint="@string/search_subreddit_hint">
+
+        </EditText>
+    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,8 @@
     <string name="search_title_prefix">[beta] Search: </string>
     <string name="search_hint">[beta] Search reddit</string>
     <string name="search_sort_label">Sort results by </string>
- 	<string-array name="search_results_sorting">
+	<string name="search_subreddit_hint">[Optional] subreddit</string>
+	<string-array name="search_results_sorting">
         <item>relevant</item>
         <item>new</item>
         <item>top</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -345,5 +345,7 @@
 
 	<!-- Miscellaneous Strings -->
 	<string name="comment_by_string">Comment by %s</string>
+    <string name="channel_name">Inbox</string>
+	<string name="channel_id">inbox</string>
 
 </resources>


### PR DESCRIPTION
This fixes our previous workaround where we targeted the latest sdk version but continued to compile for version 15. Doing that broke notifications for Oreo+, as we didn't handle notification channels while targeting those newer versions. This targets Android Q and makes the following changes:

 - Notifications now work on Honeycomb+, but are probably now broken on anything under that. Necessary APIs for setting notification content were removed and Google expects us to use the support library's NotificationCompat, but the library requires API 14+, so it doesn't work for us. Maybe someone else could figure out a solution.

 - The ability to read/write to global browser history and favorites was removed in Marshmallow, so that functionality was commented out. We should probably remove traces of those from settings as well.

 - Google also removed Apache HttpClient in Marshmallow, but we bring it back in anyways and set that we are targeting the legacy behavior in the Manifest.

As far as I can tell, everything works correctly now, but it should probably go under some more testing.